### PR TITLE
Fix pour le crash quand on quitte lua

### DIFF
--- a/src/navdata.c
+++ b/src/navdata.c
@@ -238,7 +238,7 @@ int navdata_disconnect()
 		pthread_mutex_unlock(&mutex_stopped);
 		int ret = pthread_join(navdata_thread, NULL);
 
-		jakopter_com_remove_channel(1);
+		jakopter_com_remove_channel(CHANNEL_NAVDATA);
 
 		close(sock_navdata);
 


### PR DESCRIPTION
Fonction qui s'exécute quand lua quitte et arrête les threads.
Pour l'instant ça appelle les fonctions de déconnexion standard de drone et video, du coup on a droit aux messages "machin déjà arrêté".
En tout cas ça évite de segfault si on n'appelle pas stop_video et/ou disconnect.