### PR TITLE
Fix typo (semicolon)

### DIFF
--- a/src/drone.c
+++ b/src/drone.c
@@ -372,7 +372,7 @@ int jakopter_forward(float speed)
 {
 	int ret = jakopter_move(0, -speed, 0, 0);
 
-	jakopter_stay():
+	jakopter_stay();
 
 	return ret;
 }


### PR DESCRIPTION
Juste une typo qui bloquait la compilation (signalée par M. Bodin).